### PR TITLE
moar tests!

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,48 @@
 
 Just some fun stuff with golang
 
+## Running Tests
+
+To run all tests:
+
+```bash
+go test ./...
+```
+
+To run tests with verbose output:
+
+```bash
+go test -v ./...
+```
+
+To run benchmarks:
+
+```bash
+go test -bench=. ./tinkering
+```
+
+### Token Package Integration Tests
+
+The token package includes integration tests that require a PostgreSQL database. To run these tests:
+
+1. Start the database:
+```bash
+cd token
+docker-compose up -d
+```
+
+2. Remove the skip statement in `token/token_test.go` (line 10: `t.Skip()`)
+
+3. Run the tests:
+```bash
+go test ./token -v
+```
+
+4. Stop the database when done:
+```bash
+cd token
+docker-compose down
+```
+
 ## Running
 

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -2,7 +2,54 @@ package token
 
 import (
 	"testing"
+	"time"
 )
+
+// TestTokenHelpers tests helper functions that don't require database
+func TestTokenHelpers(t *testing.T) {
+	t.Run("tokenToArgs and createToken roundtrip", func(t *testing.T) {
+		token := &Token{limit: 2}
+
+		// Create test data
+		testTime := time.Date(2024, 1, 15, 12, 30, 45, 123456789, time.UTC)
+		testFoos := []Foo{
+			{ID: 1, Data: "first", UpdatedAt: testTime},
+			{ID: 2, Data: "second", UpdatedAt: testTime},
+			{ID: 3, Data: "third", UpdatedAt: testTime},
+		}
+
+		// Create token from foos
+		tokenStr := token.createToken(testFoos)
+
+		// Parse it back
+		id, parsedTime := token.tokenToArgs(tokenStr)
+
+		// Verify the roundtrip
+		if id != 3 {
+			t.Errorf("expected id 3, got %d", id)
+		}
+		if !parsedTime.Equal(testTime) {
+			t.Errorf("expected time %v, got %v", testTime, parsedTime)
+		}
+	})
+
+	t.Run("toJSON creates valid json", func(t *testing.T) {
+		testTime := time.Date(2024, 1, 15, 12, 30, 45, 0, time.UTC)
+		testFoos := []Foo{
+			{ID: 1, Data: "test", CreatedAt: testTime, UpdatedAt: testTime},
+		}
+
+		result := toJSON(testFoos, "old_token", "new_token")
+
+		// Basic validation that we got JSON back
+		if len(result) == 0 {
+			t.Error("expected non-empty JSON result")
+		}
+		if result[0] != '{' {
+			t.Error("expected JSON to start with {")
+		}
+	})
+}
 
 // TestToken tests some implementations of selecting records with a token
 // each record should be returned to client at least once (dups are ok)


### PR DESCRIPTION
Adds some docs + tests

- Add unit tests for token package helper functions (tokenToArgs, createToken, toJSON)
- Document how to run tests in README including regular tests, verbose mode, and benchmarks
- Document integration test setup requiring PostgreSQL database
- All tests now pass successfully in CI without external dependencies